### PR TITLE
Sort duplicate groups for stable output

### DIFF
--- a/deduplicator/deduplicator.go
+++ b/deduplicator/deduplicator.go
@@ -1,6 +1,8 @@
 // deduplicator.go
 package deduplicator
 
+import "sort"
+
 func FindDuplicates(files []FileInfo) []DuplicateGroup {
 	hashMap := make(map[string][]FileInfo)
 
@@ -8,8 +10,15 @@ func FindDuplicates(files []FileInfo) []DuplicateGroup {
 		hashMap[f.Hash] = append(hashMap[f.Hash], f)
 	}
 
+	keys := make([]string, 0, len(hashMap))
+	for k := range hashMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var duplicates []DuplicateGroup
-	for hash, group := range hashMap {
+	for _, hash := range keys {
+		group := hashMap[hash]
 		if len(group) > 1 {
 			duplicates = append(duplicates, DuplicateGroup{
 				Hash:  hash,


### PR DESCRIPTION
## Summary
- ensure stable deduplication results by iterating through sorted hash keys

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a0ed2d33c8328a5e1c8f42ac5927d