### PR TITLE
Use worker pool to hash files concurrently

### DIFF
--- a/deduplicator/walker.go
+++ b/deduplicator/walker.go
@@ -5,31 +5,62 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 )
 
 func WalkAndHash(root string, hashFunc func(string) (string, error)) ([]FileInfo, error) {
-	var files []FileInfo
+	var (
+		files   []FileInfo
+		paths   = make(chan string)
+		results = make(chan FileInfo)
+		wg      sync.WaitGroup
+	)
 
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return nil // ignorar errores o carpetas
-		}
+	workerCount := runtime.NumCPU()
+	wg.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer wg.Done()
+			for path := range paths {
+				info, err := os.Stat(path)
+				if err != nil {
+					continue
+				}
+				hash, err := hashFunc(path)
+				if err != nil {
+					continue
+				}
+				results <- FileInfo{
+					Path:         path,
+					Size:         info.Size(),
+					Hash:         hash,
+					LastModified: info.ModTime().Unix(),
+				}
+			}
+		}()
+	}
 
-		info, _ := os.Stat(path)
-		hash, err := hashFunc(path)
-		if err != nil {
-			return nil // opcional: loggear errores por archivo
-		}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
 
-		files = append(files, FileInfo{
-			Path:         path,
-			Size:         info.Size(),
-			Hash:         hash,
-			LastModified: info.ModTime().Unix(),
+	walkErr := make(chan error, 1)
+	go func() {
+		walkErr <- filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			paths <- path
+			return nil
 		})
+		close(paths)
+	}()
 
-		return nil
-	})
+	for fi := range results {
+		files = append(files, fi)
+	}
 
-	return files, err
+	return files, <-walkErr
 }


### PR DESCRIPTION
## Summary
- parallelize WalkAndHash using goroutines and channels
- fix deadlock by processing directory walk in a goroutine and collecting worker results concurrently

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a12eb21c48328a643cfd6b82b9917