### PR TITLE
Add JSON tags for exported types

### DIFF
--- a/deduplicator/formatter.go
+++ b/deduplicator/formatter.go
@@ -7,10 +7,10 @@ import (
 )
 
 type DuplicateReport struct {
-	Groups          []DuplicateGroup `json:"groups"`
-	TotalFiles      int                           `json:"total_duplicated_files"`
-	TotalWasted     int64                         `json:"total_wasted_bytes"`
-	TotalGroups     int                           `json:"total_groups"`
+	Groups      []DuplicateGroup `json:"groups"`
+	TotalFiles  int              `json:"total_duplicated_files"`
+	TotalWasted int64            `json:"total_wasted_bytes"`
+	TotalGroups int              `json:"total_groups"`
 }
 
 // PrettyPrint imprime el resultado formateado para humanos

--- a/deduplicator/types.go
+++ b/deduplicator/types.go
@@ -2,13 +2,13 @@
 package deduplicator
 
 type FileInfo struct {
-	Path         string
-	Size         int64
-	Hash         string
-	LastModified int64
+	Path         string `json:"path"`
+	Size         int64  `json:"size"`
+	Hash         string `json:"hash"`
+	LastModified int64  `json:"lastModified"`
 }
 
 type DuplicateGroup struct {
-	Hash      string
-	Files     []FileInfo
+	Hash  string     `json:"hash"`
+	Files []FileInfo `json:"files"`
 }


### PR DESCRIPTION
## Summary
- add json tags to FileInfo and DuplicateGroup
- fix formatter struct tags for JSON output

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e2664ad7883289fbfb01d4b6debfa