### PR TITLE
Copy files slice before sorting

### DIFF
--- a/deduplicator/formatter.go
+++ b/deduplicator/formatter.go
@@ -32,7 +32,7 @@ func PrettyPrint(dupes []DuplicateGroup) {
 		fmt.Printf("🔁 Grupo #%d — %d archivos duplicados (Hash: %s)\n", i+1, numFiles, group.Hash)
 		fmt.Printf("    Tamaño por archivo: %d bytes | Total duplicado: %d bytes\n", sizePerFile, wasted)
 
-		sorted := group.Files
+		sorted := append([]FileInfo(nil), group.Files...)
 		sort.Slice(sorted, func(i, j int) bool {
 			return sorted[i].Path < sorted[j].Path
 		})


### PR DESCRIPTION
## Summary
- avoid mutating the original duplicate list when formatting by copying slice before sorting

## Testing
- `go test ./...`
- `go vet ./... && echo vet OK`


------
https://chatgpt.com/codex/tasks/task_e_689e2817eca88328bffe6df717040b60