### PR TITLE
Add selectable hash algorithms to CLI

### DIFF
--- a/deduplicator/hasher.go
+++ b/deduplicator/hasher.go
@@ -2,11 +2,42 @@
 package deduplicator
 
 import (
+	"crypto/md5"
+	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"io"
 	"os"
 )
+
+func HashFileMD5(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func HashFileSHA1(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha1.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
 
 func HashFileSHA256(path string) (string, error) {
 	f, err := os.Open(path)
@@ -16,6 +47,20 @@ func HashFileSHA256(path string) (string, error) {
 	defer f.Close()
 
 	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func HashFileSHA512(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha512.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	// Flags de entrada
 	dir := flag.String("dir", "", "Ruta del directorio a analizar")
 	format := flag.String("format", "pretty", "Formato de salida: pretty | json")
+	hashAlg := flag.String("hash", "sha256", "Algoritmo de hash: sha256 | sha1 | sha512 | md5")
 	var excludes multiFlag
 	flag.Var(&excludes, "exclude", "Patrones o rutas a excluir (puede usarse varias veces)")
 	flag.Parse()
@@ -35,8 +36,23 @@ func main() {
 
 	fmt.Printf("Analizando directorio: %s\n", *dir)
 
+	var hashFunc func(string) (string, error)
+	switch *hashAlg {
+	case "sha256":
+		hashFunc = deduplicator.HashFileSHA256
+	case "sha1":
+		hashFunc = deduplicator.HashFileSHA1
+	case "sha512":
+		hashFunc = deduplicator.HashFileSHA512
+	case "md5":
+		hashFunc = deduplicator.HashFileMD5
+	default:
+		fmt.Printf("Algoritmo de hash no soportado: %s\n", *hashAlg)
+		os.Exit(1)
+	}
+
 	// Escanear archivos y calcular hashes
-	files, err := deduplicator.WalkAndHash(*dir, []string(excludes), deduplicator.HashFileSHA256)
+	files, err := deduplicator.WalkAndHash(*dir, []string(excludes), hashFunc)
 	if err != nil {
 		log.Fatalf("Error durante el escaneo: %v", err)
 	}
@@ -49,15 +65,15 @@ func main() {
 		return
 	}
 	/*
-		// Mostrar resultados
-		fmt.Printf("Se encontraron %d grupos de duplicados:\n\n", len(dupes))
-		for i, group := range dupes {
-			fmt.Printf("Grupo #%d (Hash: %s)\n", i+1, group.Hash)
-			for _, f := range group.Files {
-				fmt.Printf("  - %s (%d bytes)\n", f.Path, f.Size)
-			}
-			fmt.Println()
-		}
+	   // Mostrar resultados
+	   fmt.Printf("Se encontraron %d grupos de duplicados:\n\n", len(dupes))
+	   for i, group := range dupes {
+	   fmt.Printf("Grupo #%d (Hash: %s)\n", i+1, group.Hash)
+	   for _, f := range group.Files {
+	   fmt.Printf("  - %s (%d bytes)\n", f.Path, f.Size)
+	   }
+	   fmt.Println()
+	   }
 	*/
 	switch *format {
 	case "json":
@@ -72,39 +88,39 @@ func main() {
 	}
 	// Mostrar resultados mejorados
 	/*
-		totalDuplicatedFiles := 0
-		totalWastedBytes := int64(0)
+	   totalDuplicatedFiles := 0
+	   totalWastedBytes := int64(0)
 
-		for i, group := range dupes {
-			numFiles := len(group.Files)
-			if numFiles <= 1 {
-				continue // debería ser innecesario, pero por seguridad
-			}
+	   for i, group := range dupes {
+	   numFiles := len(group.Files)
+	   if numFiles <= 1 {
+	   continue // debería ser innecesario, pero por seguridad
+	   }
 
-			sizePerFile := group.Files[0].Size
-			wasted := int64(numFiles-1) * sizePerFile
-			totalDuplicatedFiles += numFiles - 1
-			totalWastedBytes += wasted
+	   sizePerFile := group.Files[0].Size
+	   wasted := int64(numFiles-1) * sizePerFile
+	   totalDuplicatedFiles += numFiles - 1
+	   totalWastedBytes += wasted
 
-			fmt.Printf("🔁 Grupo #%d — %d archivos duplicados (Hash: %s)\n", i+1, numFiles, group.Hash)
-			fmt.Printf("    Tamaño por archivo: %d bytes | Total duplicado: %d bytes\n", sizePerFile, wasted)
+	   fmt.Printf("🔁 Grupo #%d — %d archivos duplicados (Hash: %s)\n", i+1, numFiles, group.Hash)
+	   fmt.Printf("    Tamaño por archivo: %d bytes | Total duplicado: %d bytes\n", sizePerFile, wasted)
 
-			// Ordenar las rutas para facilitar lectura
-			sorted := group.Files
-			sort.Slice(sorted, func(i, j int) bool {
-				return sorted[i].Path < sorted[j].Path
-			})
+	   // Ordenar las rutas para facilitar lectura
+	   sorted := group.Files
+	   sort.Slice(sorted, func(i, j int) bool {
+	   return sorted[i].Path < sorted[j].Path
+	   })
 
-			for _, f := range sorted {
-				fmt.Printf("    - %s\n", f.Path)
-			}
-			fmt.Println()
-		}
+	   for _, f := range sorted {
+	   fmt.Printf("    - %s\n", f.Path)
+	   }
+	   fmt.Println()
+	   }
 
-		// Resumen final
-		fmt.Println("📊 Resumen:")
-		fmt.Printf("  - Total de grupos de duplicados: %d\n", len(dupes))
-		fmt.Printf("  - Total de archivos duplicados: %d\n", totalDuplicatedFiles)
-		fmt.Printf("  - Espacio potencial recuperable: %.2f MB\n", float64(totalWastedBytes)/1024.0/1024.0)
+	   // Resumen final
+	   fmt.Println("📊 Resumen:")
+	   fmt.Printf("  - Total de grupos de duplicados: %d\n", len(dupes))
+	   fmt.Printf("  - Total de archivos duplicados: %d\n", totalDuplicatedFiles)
+	   fmt.Printf("  - Espacio potencial recuperable: %.2f MB\n", float64(totalWastedBytes)/1024.0/1024.0)
 	*/
 }


### PR DESCRIPTION
## Summary
- add `--hash` flag to choose hash algorithm
- implement MD5, SHA1 and SHA512 file hashers
- wire selected hasher into directory walk

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e7579426c8328ab7ce0396acfd83b