### PR TITLE
Add deletion flag and duplicate removal tests

### DIFF
--- a/deduplicator/deleter.go
+++ b/deduplicator/deleter.go
@@ -1,0 +1,27 @@
+package deduplicator
+
+import (
+	"fmt"
+	"os"
+)
+
+// DeleteDuplicates elimina las copias redundantes de cada grupo dejando
+// el primer archivo intacto. Devuelve las rutas que fueron (o serían)
+// eliminadas.
+func DeleteDuplicates(groups []DuplicateGroup, dryRun bool) ([]string, error) {
+	var removed []string
+	for _, g := range groups {
+		for i := 1; i < len(g.Files); i++ {
+			path := g.Files[i].Path
+			removed = append(removed, path)
+			if dryRun {
+				fmt.Printf("[dry-run] eliminar %s\n", path)
+				continue
+			}
+			if err := os.Remove(path); err != nil {
+				return removed, err
+			}
+		}
+	}
+	return removed, nil
+}

--- a/deduplicator/deleter_test.go
+++ b/deduplicator/deleter_test.go
@@ -1,0 +1,78 @@
+package deduplicator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeleteDuplicates(t *testing.T) {
+	dir := t.TempDir()
+
+	g1a := filepath.Join(dir, "g1a")
+	g1b := filepath.Join(dir, "g1b")
+	g1c := filepath.Join(dir, "g1c")
+	for _, p := range []string{g1a, g1b, g1c} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	g2a := filepath.Join(dir, "g2a")
+	g2b := filepath.Join(dir, "g2b")
+	for _, p := range []string{g2a, g2b} {
+		if err := os.WriteFile(p, []byte("y"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	groups := []DuplicateGroup{
+		{Hash: "h1", Files: []FileInfo{{Path: g1a}, {Path: g1b}, {Path: g1c}}},
+		{Hash: "h2", Files: []FileInfo{{Path: g2a}, {Path: g2b}}},
+	}
+
+	removed, err := DeleteDuplicates(groups, false)
+	if err != nil {
+		t.Fatalf("DeleteDuplicates: %v", err)
+	}
+	if len(removed) != 3 {
+		t.Fatalf("expected 3 deletions, got %d", len(removed))
+	}
+
+	if _, err := os.Stat(g1a); err != nil {
+		t.Fatalf("kept file missing: %v", err)
+	}
+	if _, err := os.Stat(g2a); err != nil {
+		t.Fatalf("kept file missing: %v", err)
+	}
+	for _, p := range []string{g1b, g1c, g2b} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("%s was not deleted", p)
+		}
+	}
+}
+
+func TestDeleteDuplicatesDryRun(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	for _, p := range []string{a, b} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	groups := []DuplicateGroup{{Hash: "h", Files: []FileInfo{{Path: a}, {Path: b}}}}
+
+	removed, err := DeleteDuplicates(groups, true)
+	if err != nil {
+		t.Fatalf("DeleteDuplicates dry-run: %v", err)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 removal in dry-run, got %d", len(removed))
+	}
+	for _, p := range []string{a, b} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("file %s should exist: %v", p, err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ func main() {
 	dir := flag.String("dir", "", "Ruta del directorio a analizar")
 	format := flag.String("format", "pretty", "Formato de salida: pretty | json")
 	hashAlg := flag.String("hash", "sha256", "Algoritmo de hash: sha256 | sha1 | sha512 | md5")
+	deleteFlag := flag.Bool("delete", false, "Eliminar automáticamente los archivos duplicados")
+	dryRun := flag.Bool("dry-run", false, "Simular la eliminación sin borrar archivos")
 	var excludes multiFlag
 	flag.Var(&excludes, "exclude", "Patrones o rutas a excluir (puede usarse varias veces)")
 	flag.Parse()
@@ -85,6 +87,18 @@ func main() {
 	default:
 		fmt.Printf("Formato no reconocido: %s\n", *format)
 		os.Exit(1)
+	}
+
+	if *deleteFlag {
+		removed, err := deduplicator.DeleteDuplicates(dupes, *dryRun)
+		if err != nil {
+			log.Fatalf("Error al eliminar duplicados: %v", err)
+		}
+		if *dryRun {
+			fmt.Printf("Se eliminarían %d archivos duplicados.\n", len(removed))
+		} else {
+			fmt.Printf("Se eliminaron %d archivos duplicados.\n", len(removed))
+		}
 	}
 	// Mostrar resultados mejorados
 	/*


### PR DESCRIPTION
## Summary
- add `--delete` and `--dry-run` CLI flags
- implement duplicate removal helper
- cover deletion logic with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ef0c18b188328a00284311aeabd6c