### PR TITLE
Use goroutines to scan directories in walker

### DIFF
--- a/deduplicator/config.go
+++ b/deduplicator/config.go
@@ -1,0 +1,4 @@
+package deduplicator
+
+// MeasureTimings enables logging of goroutine durations when set to true.
+var MeasureTimings bool

--- a/deduplicator/walker.go
+++ b/deduplicator/walker.go
@@ -103,7 +103,13 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 							continue
 						}
 						dirWG.Add(1)
-						dirs <- path
+						// Avoid blocking all workers when channel is full:
+						// try to send, but fall back to a goroutine if the queue is saturated.
+						select {
+						case dirs <- path:
+						default:
+							go func(p string) { dirs <- p }(path)
+						}
 						continue
 					}
 					if isExcluded(name) {

--- a/deduplicator/walker.go
+++ b/deduplicator/walker.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 )
 
 // WalkAndHash recorre el directorio, agrupa primero por tamaño y solo
@@ -28,69 +29,110 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 		modTime int64
 	}
 
-	// Primer paso: construir un mapa size -> []job
+	// Primer paso: construir un mapa size -> []job mediante escaneo manual
 	sizeMap := make(map[int64][]job)
 	visited := make(map[string]struct{})
-	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.Type()&fs.ModeSymlink != 0 {
-			target, err := os.Readlink(path)
-			if err != nil {
-				return nil
+	var (
+		sizeMu    sync.Mutex
+		visitedMu sync.Mutex
+	)
+
+	dirs := make(chan string, runtime.NumCPU()*4)
+	var dirWG sync.WaitGroup
+	var workerWG sync.WaitGroup
+
+	scanWorkers := runtime.NumCPU()
+	workerWG.Add(scanWorkers)
+	for i := 0; i < scanWorkers; i++ {
+		go func(id int) {
+			start := time.Now()
+			defer func() {
+				if MeasureTimings {
+					log.Printf("scan worker %d took %v", id, time.Since(start))
+				}
+				workerWG.Done()
+			}()
+			for dir := range dirs {
+				entries, err := os.ReadDir(dir)
+				if err != nil {
+					log.Printf("error reading %s: %v", dir, err)
+					dirWG.Done()
+					continue
+				}
+				for _, entry := range entries {
+					name := entry.Name()
+					path := filepath.Join(dir, name)
+					if entry.Type()&fs.ModeSymlink != 0 {
+						target, err := os.Readlink(path)
+						if err != nil {
+							continue
+						}
+						if !filepath.IsAbs(target) {
+							target = filepath.Join(dir, target)
+						}
+						target, err = filepath.Abs(target)
+						if err != nil {
+							continue
+						}
+						target = filepath.Clean(target)
+						visitedMu.Lock()
+						if _, ok := visited[target]; ok {
+							visitedMu.Unlock()
+							continue
+						}
+						visited[target] = struct{}{}
+						visitedMu.Unlock()
+						if isExcluded(filepath.Base(target)) {
+							continue
+						}
+						info, err := os.Stat(target)
+						if err != nil || info.IsDir() {
+							continue
+						}
+						sizeMu.Lock()
+						sizeMap[info.Size()] = append(sizeMap[info.Size()], job{
+							path:    target,
+							size:    info.Size(),
+							modTime: info.ModTime().Unix(),
+						})
+						sizeMu.Unlock()
+						continue
+					}
+					if entry.IsDir() {
+						if isExcluded(name) {
+							continue
+						}
+						dirWG.Add(1)
+						dirs <- path
+						continue
+					}
+					if isExcluded(name) {
+						continue
+					}
+					info, err := entry.Info()
+					if err != nil {
+						continue
+					}
+					sizeMu.Lock()
+					sizeMap[info.Size()] = append(sizeMap[info.Size()], job{
+						path:    path,
+						size:    info.Size(),
+						modTime: info.ModTime().Unix(),
+					})
+					sizeMu.Unlock()
+				}
+				dirWG.Done()
 			}
-			if !filepath.IsAbs(target) {
-				target = filepath.Join(filepath.Dir(path), target)
-			}
-			target, err = filepath.Abs(target)
-			if err != nil {
-				return nil
-			}
-			target = filepath.Clean(target)
-			if _, ok := visited[target]; ok {
-				return nil
-			}
-			visited[target] = struct{}{}
-			if isExcluded(filepath.Base(target)) {
-				return nil
-			}
-			info, err := os.Stat(target)
-			if err != nil {
-				return nil
-			}
-			if info.IsDir() {
-				return nil
-			}
-			sizeMap[info.Size()] = append(sizeMap[info.Size()], job{
-				path:    target,
-				size:    info.Size(),
-				modTime: info.ModTime().Unix(),
-			})
-			return nil
-		}
-		if d.IsDir() {
-			if isExcluded(d.Name()) {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if isExcluded(d.Name()) {
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		sizeMap[info.Size()] = append(sizeMap[info.Size()], job{
-			path:    path,
-			size:    info.Size(),
-			modTime: info.ModTime().Unix(),
-		})
-		return nil
-	}); err != nil {
-		return nil, err
+		}(i)
 	}
+
+	dirWG.Add(1)
+	dirs <- root
+	go func() {
+		dirWG.Wait()
+		close(dirs)
+	}()
+	workerWG.Wait()
 
 	var (
 		files   []FileInfo
@@ -102,8 +144,14 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 	workerCount := runtime.NumCPU()
 	wg.Add(workerCount)
 	for i := 0; i < workerCount; i++ {
-		go func() {
-			defer wg.Done()
+		go func(id int) {
+			start := time.Now()
+			defer func() {
+				if MeasureTimings {
+					log.Printf("hash worker %d took %v", id, time.Since(start))
+				}
+				wg.Done()
+			}()
 			for j := range paths {
 				hash, err := hashFunc(j.path)
 				if err != nil {
@@ -117,7 +165,7 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 					LastModified: j.modTime,
 				}
 			}
-		}()
+		}(i)
 	}
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	hashAlg := flag.String("hash", "sha256", "Algoritmo de hash: sha256 | sha1 | sha512 | md5")
 	deleteFlag := flag.Bool("delete", false, "Eliminar automáticamente los archivos duplicados")
 	dryRun := flag.Bool("dry-run", false, "Simular la eliminación sin borrar archivos")
+	timings := flag.Bool("timings", false, "Mostrar duración de cada goroutine")
 	var excludes = multiFlag{".git", "node_modules", ".github", ".idea", ".vscode", "vendor", "dist", "build", "tmp", "temp", ".venv", "venv"}
 	flag.Var(&excludes, "exclude", "Patrones o rutas a excluir (puede usarse varias veces)")
 	flag.Parse()
@@ -37,6 +38,10 @@ func main() {
 	}
 
 	fmt.Printf("Analizando directorio: %s\n", *dir)
+
+	if *timings {
+		deduplicator.MeasureTimings = true
+	}
 
 	var hashFunc func(string) (string, error)
 	switch *hashAlg {


### PR DESCRIPTION
## Summary
- Replace `filepath.WalkDir` with custom concurrent scan
- Channel-based directory traversal using `os.ReadDir`
- Preserve symlink handling and exclusions
- Buffer directory queue to prevent deadlock and optionally log per-goroutine timings

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0a5b9c404832888632be0918857b8