### PR TITLE
Implement file hashing cache for WalkAndHash

### DIFF
--- a/deduplicator/cache.go
+++ b/deduplicator/cache.go
@@ -1,0 +1,46 @@
+package deduplicator
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// loadCache reads the cache file and returns the cache map. If the file does
+// not exist it returns an empty cache.
+func loadCache(path string) (map[string]CacheEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]CacheEntry), nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var cache map[string]CacheEntry
+	if err := json.NewDecoder(f).Decode(&cache); err != nil {
+		return nil, err
+	}
+	return cache, nil
+}
+
+// saveCache writes the cache map to the given path in JSON format.
+func saveCache(path string, cache map[string]CacheEntry) error {
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cache); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/deduplicator/types.go
+++ b/deduplicator/types.go
@@ -12,3 +12,14 @@ type DuplicateGroup struct {
 	Hash  string     `json:"hash"`
 	Files []FileInfo `json:"files"`
 }
+
+// CacheEntry represents a file entry stored in the cache.
+// It is keyed by the absolute file path and stores the size,
+// modification time and the previously computed hash so we can
+// avoid recalculating hashes for unchanged files.
+type CacheEntry struct {
+	Path    string `json:"path"`
+	Size    int64  `json:"size"`
+	ModTime int64  `json:"modTime"`
+	Hash    string `json:"hash"`
+}

--- a/deduplicator/walker.go
+++ b/deduplicator/walker.go
@@ -11,10 +11,15 @@ import (
 	"time"
 )
 
+const cacheFileName = ".dedupcache.json"
+
 // WalkAndHash recorre el directorio, agrupa primero por tamaño y solo
 // calcula el hash de los archivos que comparten tamaño con al menos otro.
 func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, error)) ([]FileInfo, error) {
 	isExcluded := func(name string) bool {
+		if name == cacheFileName {
+			return true
+		}
 		for _, pattern := range excludes {
 			if ok, _ := filepath.Match(pattern, name); ok {
 				return true
@@ -22,6 +27,14 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 		}
 		return false
 	}
+
+	cachePath := filepath.Join(root, cacheFileName)
+	cache, err := loadCache(cachePath)
+	if err != nil {
+		log.Printf("error loading cache: %v", err)
+		cache = make(map[string]CacheEntry)
+	}
+	var cacheMu sync.RWMutex
 
 	type job struct {
 		path    string
@@ -159,10 +172,27 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 				wg.Done()
 			}()
 			for j := range paths {
-				hash, err := hashFunc(j.path)
-				if err != nil {
-					log.Printf("error hashing %s: %v", j.path, err)
-					continue
+				cacheMu.RLock()
+				ce, ok := cache[j.path]
+				cacheMu.RUnlock()
+				var hash string
+				if ok && ce.Size == j.size && ce.ModTime == j.modTime {
+					hash = ce.Hash
+				} else {
+					var err error
+					hash, err = hashFunc(j.path)
+					if err != nil {
+						log.Printf("error hashing %s: %v", j.path, err)
+						continue
+					}
+					cacheMu.Lock()
+					cache[j.path] = CacheEntry{
+						Path:    j.path,
+						Size:    j.size,
+						ModTime: j.modTime,
+						Hash:    hash,
+					}
+					cacheMu.Unlock()
 				}
 				results <- FileInfo{
 					Path:         j.path,
@@ -195,6 +225,10 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 
 	for fi := range results {
 		files = append(files, fi)
+	}
+
+	if err := saveCache(cachePath, cache); err != nil {
+		log.Printf("error saving cache: %v", err)
 	}
 
 	return files, nil

--- a/deduplicator/walker_test.go
+++ b/deduplicator/walker_test.go
@@ -3,6 +3,7 @@ package deduplicator
 import (
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
@@ -67,4 +68,30 @@ func TestWalkAndHashExcludes(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestWalkAndHashCache(t *testing.T) {
+	dir := t.TempDir()
+	createFile(t, filepath.Join(dir, "a.txt"), "same")
+	createFile(t, filepath.Join(dir, "b.txt"), "same")
+
+	var count int32
+	hash := func(string) (string, error) {
+		atomic.AddInt32(&count, 1)
+		return "h", nil
+	}
+
+	if _, err := WalkAndHash(dir, nil, hash); err != nil {
+		t.Fatalf("WalkAndHash: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 hash calls, got %d", count)
+	}
+
+	if _, err := WalkAndHash(dir, nil, hash); err != nil {
+		t.Fatalf("WalkAndHash second: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected cache to prevent hashing, got %d calls", count)
+	}
 }


### PR DESCRIPTION
## Summary
- add `CacheEntry` type to track cached file hashes
- persist and load cache as JSON
- update `WalkAndHash` to reuse cached hashes and update cache
- test caching behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef86f4108328ab5bff6487722daa