### PR TITLE
Collect multiple errors from WalkAndHash

### DIFF
--- a/deduplicator/deduplicator_test.go
+++ b/deduplicator/deduplicator_test.go
@@ -9,12 +9,12 @@ import (
 
 // collectDuplicates is a helper that wraps WalkAndHash and FindDuplicates.
 func collectDuplicates(
-	walk func(string, []string, func(string) (string, error)) ([]FileInfo, error),
+	walk func(string, []string, func(string) (string, error)) ([]FileInfo, []error),
 	hash func(string) (string, error),
 ) ([]DuplicateGroup, error) {
-	files, err := walk("root", nil, hash)
-	if err != nil {
-		return nil, err
+	files, errs := walk("root", nil, hash)
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 	return FindDuplicates(files), nil
 }
@@ -38,7 +38,7 @@ func TestFindDuplicates(t *testing.T) {
 }
 
 func TestCollectDuplicatesSuccess(t *testing.T) {
-	mockWalk := func(root string, excludes []string, h func(string) (string, error)) ([]FileInfo, error) {
+	mockWalk := func(root string, excludes []string, h func(string) (string, error)) ([]FileInfo, []error) {
 		return []FileInfo{
 			{Path: "a", Size: 1, Hash: "same"},
 			{Path: "b", Size: 1, Hash: "same"},
@@ -57,12 +57,12 @@ func TestCollectDuplicatesSuccess(t *testing.T) {
 
 func TestCollectDuplicatesWalkError(t *testing.T) {
 	walkErr := errors.New("walk error")
-	mockWalk := func(root string, excludes []string, h func(string) (string, error)) ([]FileInfo, error) {
-		return nil, walkErr
+	mockWalk := func(root string, excludes []string, h func(string) (string, error)) ([]FileInfo, []error) {
+		return nil, []error{walkErr}
 	}
 	mockHash := func(path string) (string, error) { return "", nil }
 
-	if _, err := collectDuplicates(mockWalk, mockHash); err != walkErr {
+	if _, err := collectDuplicates(mockWalk, mockHash); !errors.Is(err, walkErr) {
 		t.Fatalf("expected %v, got %v", walkErr, err)
 	}
 }
@@ -83,9 +83,9 @@ func TestWalkAndHashHashError(t *testing.T) {
 		return "ok", nil
 	}
 
-	files, err := WalkAndHash(dir, nil, mockHash)
-	if err != nil {
-		t.Fatalf("WalkAndHash error: %v", err)
+	files, errs := WalkAndHash(dir, nil, mockHash)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
 	}
 	if len(files) != 1 {
 		t.Fatalf("expected 1 file, got %d", len(files))

--- a/deduplicator/walker.go
+++ b/deduplicator/walker.go
@@ -2,6 +2,7 @@
 package deduplicator
 
 import (
+	"fmt"
 	"io/fs"
 	"log"
 	"os"
@@ -15,7 +16,7 @@ const cacheFileName = ".dedupcache.json"
 
 // WalkAndHash recorre el directorio, agrupa primero por tamaño y solo
 // calcula el hash de los archivos que comparten tamaño con al menos otro.
-func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, error)) ([]FileInfo, error) {
+func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, error)) ([]FileInfo, []error) {
 	isExcluded := func(name string) bool {
 		if name == cacheFileName {
 			return true
@@ -30,11 +31,16 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 
 	cachePath := filepath.Join(root, cacheFileName)
 	cache, err := loadCache(cachePath)
+	var (
+		cacheMu sync.RWMutex
+		errs    []error
+		errsMu  sync.Mutex
+	)
 	if err != nil {
 		log.Printf("error loading cache: %v", err)
+		errs = append(errs, fmt.Errorf("loading cache: %w", err))
 		cache = make(map[string]CacheEntry)
 	}
-	var cacheMu sync.RWMutex
 
 	type job struct {
 		path    string
@@ -69,6 +75,9 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 				entries, err := os.ReadDir(dir)
 				if err != nil {
 					log.Printf("error reading %s: %v", dir, err)
+					errsMu.Lock()
+					errs = append(errs, fmt.Errorf("reading %s: %w", dir, err))
+					errsMu.Unlock()
 					dirWG.Done()
 					continue
 				}
@@ -183,6 +192,9 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 					hash, err = hashFunc(j.path)
 					if err != nil {
 						log.Printf("error hashing %s: %v", j.path, err)
+						errsMu.Lock()
+						errs = append(errs, fmt.Errorf("hashing %s: %w", j.path, err))
+						errsMu.Unlock()
 						continue
 					}
 					cacheMu.Lock()
@@ -229,7 +241,8 @@ func WalkAndHash(root string, excludes []string, hashFunc func(string) (string, 
 
 	if err := saveCache(cachePath, cache); err != nil {
 		log.Printf("error saving cache: %v", err)
+		errs = append(errs, fmt.Errorf("saving cache: %w", err))
 	}
 
-	return files, nil
+	return files, errs
 }

--- a/deduplicator/walker_test.go
+++ b/deduplicator/walker_test.go
@@ -30,9 +30,9 @@ func TestWalkAndHashExcludes(t *testing.T) {
 		}
 		createFile(t, filepath.Join(dir, "node_modules", "d.txt"), "same")
 
-		files, err := WalkAndHash(dir, []string{".git", "node_modules"}, hash)
-		if err != nil {
-			t.Fatalf("WalkAndHash: %v", err)
+		files, errs := WalkAndHash(dir, []string{".git", "node_modules"}, hash)
+		if len(errs) > 0 {
+			t.Fatalf("WalkAndHash: %v", errs)
 		}
 		if len(files) != 2 {
 			t.Fatalf("expected 2 files, got %d", len(files))
@@ -54,9 +54,9 @@ func TestWalkAndHashExcludes(t *testing.T) {
 		}
 		createFile(t, filepath.Join(dir, "vendor", "c.txt"), "same")
 
-		files, err := WalkAndHash(dir, []string{".git", "node_modules", "vendor"}, hash)
-		if err != nil {
-			t.Fatalf("WalkAndHash: %v", err)
+		files, errs := WalkAndHash(dir, []string{".git", "node_modules", "vendor"}, hash)
+		if len(errs) > 0 {
+			t.Fatalf("WalkAndHash: %v", errs)
 		}
 		if len(files) != 2 {
 			t.Fatalf("expected 2 files, got %d", len(files))
@@ -81,15 +81,15 @@ func TestWalkAndHashCache(t *testing.T) {
 		return "h", nil
 	}
 
-	if _, err := WalkAndHash(dir, nil, hash); err != nil {
-		t.Fatalf("WalkAndHash: %v", err)
+	if _, errs := WalkAndHash(dir, nil, hash); len(errs) > 0 {
+		t.Fatalf("WalkAndHash: %v", errs)
 	}
 	if count != 2 {
 		t.Fatalf("expected 2 hash calls, got %d", count)
 	}
 
-	if _, err := WalkAndHash(dir, nil, hash); err != nil {
-		t.Fatalf("WalkAndHash second: %v", err)
+	if _, errs := WalkAndHash(dir, nil, hash); len(errs) > 0 {
+		t.Fatalf("WalkAndHash second: %v", errs)
 	}
 	if count != 2 {
 		t.Fatalf("expected cache to prevent hashing, got %d calls", count)

--- a/main.go
+++ b/main.go
@@ -61,9 +61,11 @@ func main() {
 	}
 
 	// Escanear archivos y calcular hashes
-	files, err := deduplicator.WalkAndHash(*dir, []string(excludes), hashFunc)
-	if err != nil {
-		log.Printf("Error durante el escaneo: %v", err)
+	files, errs := deduplicator.WalkAndHash(*dir, []string(excludes), hashFunc)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Printf("Error durante el escaneo: %v", err)
+		}
 		exitCode = 1
 	}
 


### PR DESCRIPTION
## Summary
- Accumulate errors during directory walk and hashing in a shared slice and return them alongside file info
- Log each scan error in main while still processing successfully hashed files
- Update tests for new WalkAndHash error handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a106ba4c5883288c8b39fb2cda0717